### PR TITLE
Simplify data structs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,17 +17,17 @@ async fn main()
 {
     // init game management
     let mut score = 0;
+    let dry_t = load_texture(
+        &(TILEMAP_PATH.to_owned() + "dry_soil.png")
+    ).await.unwrap();
+    let wet_t = load_texture(
+        &(TILEMAP_PATH.to_owned() + "wet_soil.png")
+    ).await.unwrap();
+    let seedling_t = load_texture(
+        &(PLANT_PATH.to_owned() + "seedling.png")
+    ).await.unwrap();
     let mut crop_grid = CropGrid::new(
         screen_width() / 2.0, screen_height() / 2.0,
-        load_texture(
-            &(TILEMAP_PATH.to_owned() + "dry_soil.png")
-        ).await.unwrap(),
-        load_texture(
-            &(TILEMAP_PATH.to_owned() + "wet_soil.png")
-        ).await.unwrap(),
-        load_texture(
-            &(PLANT_PATH.to_owned() + "seedling.png")
-        ).await.unwrap()
     );
 
     // init player and tools
@@ -37,24 +37,24 @@ async fn main()
     let water_can = WaterCan::new();
 
     // init plants
-    let potato = Plant::new(
+    let potato = PlantType::new(
         "Potato", 0.0, 10.0, 6.0,
         Texture2D::empty(),
         load_texture(&(PLANT_PATH.to_owned() + "potato.png")).await.unwrap()
     );
-    let carrot = Plant::new(
+    let carrot = PlantType::new(
         "Carrot", 0.0, 10.0, 2.0,
         Texture2D::empty(),
         load_texture(
             &(PLANT_PATH.to_owned() + "carrot.png")
         ).await.unwrap()
     );
-    let beet = Plant::new(
+    let beet = PlantType::new(
         "Beet", 0.0, 15.0, 6.0,
         Texture2D::empty(),
         load_texture(&(PLANT_PATH.to_owned() + "beet.png")).await.unwrap()
     );
-    let tomato = Plant::new(
+    let tomato = PlantType::new(
         "Tomato", 6.0, 10.0, 10.0,
         load_texture(&(PLANT_PATH.to_owned() + "tomato_sprout.png")).await.unwrap(),
         load_texture(&(PLANT_PATH.to_owned() + "tomato.png")).await.unwrap()
@@ -118,7 +118,7 @@ async fn main()
         player.update(get_frame_time());
 
         // draw entities to screen
-        crop_grid.render();
+        crop_grid.render(&seedling_t, &dry_t, &wet_t);
         player.render();
 
         next_frame().await

--- a/src/plants.rs
+++ b/src/plants.rs
@@ -11,115 +11,82 @@ const CROP_ROWS: usize = 4;
 const CROPS_PER_ROW: usize = 5;
 
 /// structure which holds information about the space in the crop grid
-struct CropGridCell
+struct CropGridCell<'a>
 {
-    has_plant: bool,
     pos: Vec2,
     rect: Rect,
     water_level: f32,
-    seeded_t: Texture2D,
-    plant: Plant
+    plant: Option<Plant<'a>>,
 }
 
-impl CropGridCell
+impl<'a> CropGridCell<'a>
 {
-    fn new(pos: Vec2, seedling_t: Texture2D, plant: Plant) -> Self
+    fn new(pos: Vec2) -> Self
     {
         let rect = Rect::new(pos.x, pos.y, TILEMAP_SPRITE_DIM, TILEMAP_SPRITE_DIM);
         Self
         {
-            has_plant: false,
             pos,
             rect,
-            water_level: 0.0,
-            seeded_t: seedling_t,
-            plant
+            plant: None,
+            water_level: 0.,
         }
     }
 
     fn update(&mut self, dt: f32)
     {
-        if self.has_plant && !self.plant.grown && self.water_level > 0.0
+        //if there is no plant, do nothing
+        if let Some(plant) = &mut self.plant
         {
-            self.water_level -= self.plant.water_usage * dt;
-            self.plant.update(dt);
+            plant.update(dt, &mut self.water_level)
         }
+
     }
 
-    fn plant(&mut self, plant: &Plant)
+    fn plant(&mut self, plant: &'a PlantType)
     {
-        if !self.has_plant
+        if self.plant.is_none()
         {
-            self.plant.set_plant(&plant);
-            self.has_plant = true;
+            self.plant = Some(Plant::new(plant));
         }
     }
 
     fn harvest(&mut self, score: &mut i32)
     {
-        if self.has_plant && self.plant.sprouted && self.plant.grown
+        if let Some(plant) = &mut self.plant
         {
-            self.plant.current_grow_time = self.plant.grow_time;
-            self.plant.grown = false;
-
-            *score += 10;
+            plant.harvest(score);
         }
     }
 
     fn pull(&mut self, score: &mut i32)
     {
-        if self.has_plant && self.plant.grown
+        // only pull if there is a plant that is fully grown
+        if matches!(&self.plant, Some(plant) if plant.grow_counter <= 0.)
         {
-            self.plant.set_plant(&Plant::default());
-            self.has_plant = false;
-
             *score += 10;
+            self.plant = None;
         }
     }
 
-    fn render(&self)
-    {
-        let offset = 10.0
-            + (32.0 * ((self.plant.plant_t.height() / TILEMAP_SPRITE_DIM) - 1.0));
-        if self.has_plant && self.plant.grown
-        {
-            draw_texture(
-                self.plant.plant_t,
-                self.pos.x,
-                self.pos.y - offset,
-                WHITE
-            );
+    fn render(
+        &self,
+        seeded_t: &Texture2D,
+        dry_t: &Texture2D,
+        wet_t: &Texture2D,
+    ) {
+        // render the ground, wet or dry
+        let ground = if self.water_level > 0. { *wet_t } else { *dry_t };
+        draw_texture(ground, self.pos.x, self.pos.y, WHITE);
+        // only render the plant, if there is one
+        if let Some(plant) = &self.plant {
+            plant.render(seeded_t, self.pos.x, self.pos.y);
         }
-        // otherwise, check plant has sprouted
-        else if self.has_plant && self.plant.sprouted
-        {
-            draw_texture(
-                self.plant.sprout_t,
-                self.pos.x,
-                self.pos.y - offset,
-                WHITE
-            );
-        }
-        // otherwise, assume communication there is something in the cell
-        else if self.has_plant
-        {
-            draw_texture(
-                self.seeded_t,
-                self.pos.x,
-                self.pos.y - 10.0,
-                WHITE
-            );
-        }
-    }
-
-    fn has_water(&self) -> bool
-    {
-        self.water_level > 0.0
     }
 
     fn water(&mut self, portion: f32)
     {
-        if !self.has_water()
+        if self.water_level <= 0.0
         {
             self.water_level = portion;
         }
@@ -127,23 +94,16 @@ impl CropGridCell
 }
 
 /// structure which represents places on the ground crops can be planted
-pub struct CropGrid
+pub struct CropGrid<'a>
 {
     pos: Vec2,
     screen_partition: Vec2,
-    dry_t: Texture2D,
-    watered_t: Texture2D,
-    crops: Vec<CropGridCell>
+    crops: Vec<CropGridCell<'a>>
 }
 
-impl CropGrid
+impl<'a> CropGrid<'a>
 {
-    pub fn new(
-        x: f32, y: f32,
-        dry_t: Texture2D,
-        watered_t: Texture2D,
-        seedling_t: Texture2D
-    ) -> Self
+    pub fn new(x: f32, y: f32) -> Self
     {
         let area = CROP_ROWS * CROPS_PER_ROW;
         let pos = Vec2::new(x, y);
@@ -152,174 +112,100 @@ impl CropGrid
             screen_height() / CROP_ROWS as f32
         );
 
+        let x_init = (pos.x / CROPS_PER_ROW as f32)
+            - (TILEMAP_SPRITE_DIM / 2.0);
+        let y_init = (pos.y / CROP_ROWS as f32)
+            - (TILEMAP_SPRITE_DIM / 2.0);
         let mut crops = Vec::with_capacity(area);
         // initialize crops
+        for row in 0..CROP_ROWS
         {
-            let x_init = (pos.x / CROPS_PER_ROW as f32)
-                - (TILEMAP_SPRITE_DIM / 2.0);
-            let mut y = (pos.y / CROP_ROWS as f32)
-                - (TILEMAP_SPRITE_DIM / 2.0);
+            let y = y_init + (row as f32 * screen_partition.y);
 
-            for _row in 0..CROP_ROWS
+            for col in 0..CROPS_PER_ROW
             {
-                let mut x = x_init;
-                for _col in 0..CROPS_PER_ROW
-                {
-                    let pos = Vec2::new(x, y);
-                    crops.push(CropGridCell::new(
-                        pos, seedling_t, Plant::default()
-                    ));
-                    x += screen_partition.x;
-                }
-                y += screen_partition.y;
+                let x = x_init + (col as f32 * screen_partition.x);
+                let pos = Vec2::new(x, y);
+                crops.push(CropGridCell::new(pos));
             }
         }
 
-        Self { pos, screen_partition, dry_t, watered_t, crops }
+        Self { pos, screen_partition, crops }
     }
 
-    pub fn check_for_intersect(
-        &mut self,
-        index: &mut i32,
+    fn check_for_intersect<'b>(
+        &'b mut self,
         query: Rect
-    ) -> Rect
+    ) -> Option<&'b mut CropGridCell<'a>>
     {
-        for i in 0..self.crops.len()
-        {
-            let intersect = self.crops[i].rect.intersect(query);
-
-            match intersect
-            {
-                Some(intersect) => {
-                    *index = i as i32;
-                    return intersect
-                },
-                None => continue
-            }
-        }
-
-        *index = -1;
-        Rect::default()
+        self.crops.iter_mut().find(|crop| crop.rect.intersect(query).is_some())
     }
 
     pub fn harvest_from_cell(&mut self, query: Rect, score: &mut i32)
     {
-        let mut crop_index: i32 = -1;
-        let intersect = self.check_for_intersect(&mut crop_index, query);
-
-        if crop_index > -1
+        if let Some(crop) = self.check_for_intersect(query)
         {
-            let crop = &mut self.crops[crop_index as usize];
             crop.harvest(score)
         }
     }
 
-    pub fn plant_to_cell(&mut self, plant: &Plant, query: Rect)
+    pub fn plant_to_cell(&mut self, plant: &'a PlantType, query: Rect)
     {
-        let mut crop_index: i32 = -1;
-        let intersect = self.check_for_intersect(&mut crop_index, query);
-
-        if crop_index > -1
+        if let Some(crop) = self.check_for_intersect(query)
         {
-            let crop = &mut self.crops[crop_index as usize];
             crop.plant(plant)
         }
     }
 
     pub fn pull_from_cell(&mut self, query: Rect, score: &mut i32)
     {
-        let mut crop_index: i32 = -1;
-        let intersect = self.check_for_intersect(&mut crop_index, query);
-
-        if crop_index > -1
+        if let Some(crop) = self.check_for_intersect(query)
         {
-            let crop = &mut self.crops[crop_index as usize];
             crop.pull(score);
         }
     }
 
     pub fn water_cell(&mut self, query: Rect, portion: f32)
     {
-        let mut crop_index: i32 = -1;
-        let intersect = self.check_for_intersect(&mut crop_index, query);
-
-        if crop_index > -1
+        if let Some(crop) = self.check_for_intersect(query)
         {
-            let crop = &mut self.crops[crop_index as usize];
             crop.water(portion);
         }
     }
 
     pub fn update(&mut self, dt: f32)
     {
-        for i in 0..self.crops.len()
+        for crop in &mut self.crops
         {
-            self.crops[i].update(dt);
+            crop.update(dt);
         }
     }
 
-    pub fn render(&self)
-    {
+    pub fn render(
+        &self,
+        seedling_t: &Texture2D,
+        dry_t: &Texture2D,
+        watered_t: &Texture2D,
+    ) {
         for crop in &self.crops
         {
-            if !crop.has_water()
-            {
-                draw_texture(
-                    self.dry_t,
-                    crop.pos.x,
-                    crop.pos.y,
-                    WHITE
-                );
-            }
-            else
-            {
-                draw_texture(
-                    self.watered_t,
-                    crop.pos.x,
-                    crop.pos.y,
-                    WHITE
-                );
-            }
-
-            crop.render();
+            crop.render(seedling_t, dry_t, watered_t);
         }
     }
 }
 
-/// structure which represents a plant
-pub struct Plant
+/// structure which represents a plant type
+pub struct PlantType
 {
-    grown: bool,
-    sprouted: bool,
     name: &'static str,
     sprout_time: f32,
     grow_time: f32,
-    current_grow_time: f32,
     water_usage: f32,
     sprout_t: Texture2D, // for plants which sprout, then produce (i.e. tomatoes)
     plant_t: Texture2D
 }
 
-impl Default for Plant {
-    fn default() -> Self
-    {
-        Self
-        {
-            grown: false,
-            sprouted: false,
-            name: "",
-            sprout_time: 0.0,
-            grow_time: 0.0,
-            current_grow_time: 0.0,
-            water_usage: 0.0,
-            sprout_t: Texture2D::empty(),
-            plant_t: Texture2D::empty()
-        }
-    }
-
-}
-
-impl Plant
+impl PlantType
 {
     pub fn new(
         name: &'static str,
@@ -332,45 +218,70 @@ impl Plant
     {
         Self
         {
-            grown: false,
-            sprouted: false,
             name,
             sprout_time,
             grow_time,
-            current_grow_time: grow_time,
             water_usage,
             sprout_t,
             plant_t
         }
     }
-
-    fn update(&mut self, dt: f32)
-    {
-        self.sprout_time -= dt;
-        if self.sprout_time <= 0.0
-        {
-            self.current_grow_time -= dt;
-            self.sprouted = self.sprout_t.ne(&Texture2D::empty());
-        }
-
-        if self.current_grow_time <= 0.0
-        {
-            self.current_grow_time = 0.0;
-            self.grown = true;
-        }
-    }
-
-    fn set_plant(&mut self, plant: &Plant)
-    {
-        self.sprouted = plant.sprouted;
-        self.grown = plant.grown;
-        self.name = plant.name.clone();
-        self.sprout_time = plant.sprout_time;
-        self.grow_time = plant.grow_time;
-        self.current_grow_time = plant.current_grow_time;
-        self.water_usage = plant.water_usage;
-        self.sprout_t = plant.sprout_t;
-        self.plant_t = plant.plant_t;
-    }
 }
 
+/// structure which represents a plant instance
+pub struct Plant<'a>
+{
+    plant_type: &'a PlantType,
+    grow_counter: f32,
+}
+
+impl<'a> Plant<'a>
+{
+    fn new(plant_type: &'a PlantType) -> Self
+    {
+        Self
+        {
+            plant_type,
+            grow_counter: plant_type.grow_time,
+        }
+    }
+
+    fn update(&mut self, dt: f32, water_level: &mut f32)
+    {
+        if self.grow_counter > 0. && *water_level > 0.0
+        {
+            *water_level -= self.plant_type.water_usage * dt;
+            self.grow_counter -= dt;
+        }
+    }
+
+    fn harvest(&mut self, score: &mut i32)
+    {
+        if self.grow_counter <= 0.
+        {
+            *score += 10;
+            self.grow_counter = self.plant_type.grow_time;
+        }
+    }
+
+    fn render(&self, seeded_t: &Texture2D, x: f32, y: f32)
+    {
+        let offset = 10.0
+            + (32.0 * ((self.plant_type.plant_t.height() / TILEMAP_SPRITE_DIM) - 1.0));
+        if self.grow_counter <= 0.
+        {
+            // plant is fully grown
+            draw_texture(self.plant_type.plant_t, x, y - offset, WHITE);
+        }
+        else if self.grow_counter <= self.plant_type.sprout_time
+        {
+            // plant has sprouted
+            draw_texture(self.plant_type.sprout_t, x, y - offset, WHITE);
+        }
+        else
+        {
+            // plant is on it's initial stage
+            draw_texture(*seeded_t, x, y - 10.0, WHITE);
+        }
+    }
+}


### PR DESCRIPTION
Here some things that I think improve/simplify the code:
* Plants "instances" are separated from plants "types".
* Avoid using unnecessary `bool`s, use the `water_level`, `grow_counter` directly.
* Make plant ("instance") a Option, None when there is no plant.
* Instead of loop using slice index, use iterators.
* Make `check_for_intersection` only return the intersecting crop cell.

I probably made too many changes at once, sorry about that.